### PR TITLE
Correct the URI of latest stage3 armv6j hfp tarball

### DIFF
--- a/raspigen
+++ b/raspigen
@@ -180,7 +180,7 @@ def latest_stage3(mirror)
    content.each_line("\n") do |line|
       line.strip!
       if not line.empty? and not line.start_with?("#")
-         latestTarball = URI::join(prefix, line)
+         latestTarball = URI::join(prefix, line[0,46])
       end
    end
 


### PR DESCRIPTION
Since the last line of latest-stage3-armv6j_hardfp.txt consists of  file name and size,
so get file name only.